### PR TITLE
Fix for bug re: missing s:auto_width variable

### DIFF
--- a/plugin/taglist-plus.vim
+++ b/plugin/taglist-plus.vim
@@ -147,6 +147,8 @@ if !exists('loaded_taglist')
     elseif Tlist_WinWidth == 'auto'
         let Tlist_WinWidth = 30
         let s:auto_width = 1
+    else
+        let s:auto_width = 0
     endif
 
     " Horizontally split taglist window height setting


### PR DESCRIPTION
Hi!  I'm pretty new to vim and also to doing pull requests so if I have done something wrong, please let me know.

I ran into a bug with vim-taglist-plus.  If I do a "let g:Tlist_WinWidth = 50" in my .vimrc, the first time the taglist window attempts to fill its contents, I get a bug that says something about the s:auto_width variable not being defined.

So, I tracked it down to line 144 in the plugin.  I just added an else statement that ensures that s:auto_width gets set to 0 and this seems to have fixed the bug.

I'm not sure if I should be fixing this in the original vim-taglist plugin or this one.  This is the one I am using, so I figured I would fix it in this one.  Again, if I did not follow proper etiquette, please let me know
